### PR TITLE
Strip windows and linux binaries

### DIFF
--- a/build-linux-only.sh
+++ b/build-linux-only.sh
@@ -16,7 +16,10 @@ rm -rf build
 rm -rf /root/output/$HOST
 mv $WORKSPACE/out/$HOST /root/output/$HOST
 
-zip -j /root/output/vertcoind-linux-x64.zip /root/output/$HOST/bin/vertcoind /root/output/$HOST/bin/vertcoin-tx /root/output/$HOST/bin/vertcoin-cli /root/output/$HOST/bin/vertcoin-wallet
-zip -j /root/output/vertcoinqt-linux-x64.zip /root/output/$HOST/bin/vertcoin-qt
+QT_BINS=("/root/output/$HOST/bin/vertcoin-qt")
+DAEMON_BINS=("/root/output/$HOST/bin/vertcoind" "/root/output/$HOST/bin/vertcoin-tx" "/root/output/$HOST/bin/vertcoin-cli" "/root/output/$HOST/bin/vertcoin-wallet")
 
+strip --strip-unneeded "${QT_BINS[@]}" "${DAEMON_BINS[@]}"
+zip -j /root/output/vertcoind-linux-x64.zip "${DAEMON_BINS[@]}"
+zip -j /root/output/vertcoinqt-linux-x64.zip "${QT_BINS[@]}"
 

--- a/build-win-only.sh
+++ b/build-win-only.sh
@@ -17,5 +17,10 @@ rm -rf build
 rm -rf /root/output/$HOST
 mv $WORKSPACE/out/$HOST /root/output/$HOST
 
-zip -j /root/output/vertcoind-windows-x64.zip /root/output/$HOST/bin/vertcoind.exe /root/output/$HOST/bin/vertcoin-tx.exe /root/output/$HOST/bin/vertcoin-cli.exe /root/output/$HOST/bin/vertcoin-wallet.exe
-zip -j /root/output/vertcoinqt-windows-x64.zip /root/output/$HOST/bin/vertcoin-qt.exe
+QT_BINS=("/root/output/$HOST/bin/vertcoin-qt.exe")
+DAEMON_BINS=("/root/output/$HOST/bin/vertcoind.exe" "/root/output/$HOST/bin/vertcoin-tx.exe" "/root/output/$HOST/bin/vertcoin-cli.exe" "/root/output/$HOST/bin/vertcoin-wallet.exe")
+
+strip --strip-unneeded "${QT_BINS[@]}" "${DAEMON_BINS[@]}"
+zip -j /root/output/vertcoind-windows-x64.zip "${DAEMON_BINS[@]}"
+zip -j /root/output/vertcoinqt-windows-x64.zip "${QT_BINS[@]}"
+


### PR DESCRIPTION
Strip debug symbols from windows and linux binaries before packaging. Previously I had to do this manually. 